### PR TITLE
pr(#16): Scheduled Release Cadence

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,12 @@ env:
 permissions:
   contents: write
 
+# Serialize release runs so push and scheduled triggers can't race
+# on tag creation or release commits.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   verify:
     if: ${{ !startsWith(github.event.head_commit.message, 'release(') && !startsWith(github.event.head_commit.message, 'release:') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,20 @@ name: Release
 on:
   push:
     branches: [main]
+  # Per-project knob: scheduled release cadence. Cron strings can
+  # only be literal in GitHub Actions — they cannot reference env
+  # or workflow inputs.
+  schedule:
+    - cron: "0 14 * * 1" # Mondays 14:00 UTC
+  workflow_dispatch:
 
 env:
   CARGO_HOME: ${{ github.workspace }}/.cache/cargo
+  # Per-project knob: which bump types cut a release immediately on
+  # push to main. All other push-triggered runs are deferred to the
+  # scheduled release. Schedule and workflow_dispatch ignore this
+  # gate (subject to the downstream tag-exists check).
+  RELEASE_IMMEDIATE_BUMPS: major
 
 permissions:
   contents: write
@@ -52,13 +63,24 @@ jobs:
         id: version
         shell: bash
         run: make version/github_actions
-      - name: Check Version Exists
+      - name: Release Gate
         id: check_version
+        env:
+          EVENT: ${{ github.event_name }}
+          BUMP: ${{ steps.version.outputs.bump_type }}
+          IMMEDIATE_BUMPS: ${{ env.RELEASE_IMMEDIATE_BUMPS }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
-          next_version="${{ steps.version.outputs.next_version }}"
-          if git rev-parse "${next_version}" >/dev/null 2>&1; then
+          decision=$(make --no-print-directory release/gate \
+            EVENT="$EVENT" BUMP="$BUMP" IMMEDIATE_BUMPS="$IMMEDIATE_BUMPS")
+          if [ "$decision" = "skip" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Version ${next_version} already exists, skipping release"
+            echo "::notice::Release gated by cadence policy (event=$EVENT, bump=$BUMP, immediate=$IMMEDIATE_BUMPS)"
+            exit 0
+          fi
+          if git rev-parse "$NEXT_VERSION" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Version $NEXT_VERSION already exists, skipping release"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "0 14 * * 1" # Mondays 14:00 UTC
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute the next version and skip tag/release/publish."
+        type: boolean
+        default: false
 
 env:
   CARGO_HOME: ${{ github.workspace }}/.cache/cargo
@@ -76,7 +81,13 @@ jobs:
           BUMP: ${{ steps.version.outputs.bump_type }}
           IMMEDIATE_BUMPS: ${{ env.RELEASE_IMMEDIATE_BUMPS }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dry run requested; would have released $NEXT_VERSION"
+            exit 0
+          fi
           decision=$(make --no-print-directory release/gate \
             EVENT="$EVENT" BUMP="$BUMP" IMMEDIATE_BUMPS="$IMMEDIATE_BUMPS")
           if [ "$decision" = "skip" ]; then

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,16 @@ version/github_actions:
 # Release
 # ============================================================================
 
-.PHONY: release/commit release/tag
+.PHONY: release/commit release/tag release/gate
+
+## Decide whether the current trigger should cut a release
+##
+## EVENT           push | schedule | workflow_dispatch
+## BUMP            major | minor | patch
+## IMMEDIATE_BUMPS comma-separated list, default "major"
+release/gate:
+	@EVENT="$(EVENT)" BUMP="$(BUMP)" IMMEDIATE_BUMPS="$(IMMEDIATE_BUMPS)" \
+		./scripts/release_gate.sh
 
 ## Commit release artifacts (CHANGELOG, manpage, etc.)
 release/commit:

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event="${EVENT:-}"
+bump="${BUMP:-}"
+immediate="${IMMEDIATE_BUMPS:-major}"
+
+if [ -z "$event" ]; then
+    echo "ERROR: EVENT is required" >&2
+    exit 1
+fi
+if [ -z "$bump" ]; then
+    echo "ERROR: BUMP is required" >&2
+    exit 1
+fi
+
+# Schedule and manual dispatch always proceed; downstream
+# tag-exists check no-ops if there's nothing new to release.
+if [ "$event" != "push" ]; then
+    echo "release"
+    exit 0
+fi
+
+# Push events only release when the bump type is in the
+# configured immediate-release list.
+case ",${immediate}," in
+    *",${bump},"*) echo "release" ;;
+    *)             echo "skip"    ;;
+esac

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -9,10 +9,6 @@ if [ -z "$event" ]; then
     echo "ERROR: EVENT is required" >&2
     exit 1
 fi
-if [ -z "$bump" ]; then
-    echo "ERROR: BUMP is required" >&2
-    exit 1
-fi
 
 # Schedule and manual dispatch always proceed; downstream
 # tag-exists check no-ops if there's nothing new to release.
@@ -23,6 +19,10 @@ fi
 
 # Push events only release when the bump type is in the
 # configured immediate-release list.
+if [ -z "$bump" ]; then
+    echo "ERROR: BUMP is required for push events" >&2
+    exit 1
+fi
 case ",${immediate}," in
     *",${bump},"*) echo "release" ;;
     *)             echo "skip"    ;;

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -5,6 +5,10 @@ event="${EVENT:-}"
 bump="${BUMP:-}"
 immediate="${IMMEDIATE_BUMPS:-major}"
 
+# Tolerate "major, minor" — otherwise a stray space silently
+# defeats the match.
+immediate="${immediate// /}"
+
 if [ -z "$event" ]; then
     echo "ERROR: EVENT is required" >&2
     exit 1


### PR DESCRIPTION
Replaces release-on-every-push with three triggers: scheduled cron (default Mondays 14:00 UTC) for batched releases, workflow_dispatch for manual override, and push to main gated by bump type (default: major only). Cadence decision lives in scripts/release_gate.sh and make release/gate, keeping the workflow a thin invocation layer.

Refs #15

Closes #15